### PR TITLE
Fix/err

### DIFF
--- a/ark-bcs/src/bcs/transcript.rs
+++ b/ark-bcs/src/bcs/transcript.rs
@@ -141,7 +141,7 @@ where
         }
     }
 
-    /// Register a virtual oracle specfied by coset evaluator.
+    /// Register a virtual oracle specified by coset evaluator.
     /// * `coset_query_evaluator`: a function that takes a coset and constituent
     ///   oracles, and return query responses
     /// * `evaluation_on_domain`: evaluation of this virtual round on evaluation

--- a/ark-bcs/src/ldt/rl_ldt.rs
+++ b/ark-bcs/src/ldt/rl_ldt.rs
@@ -98,7 +98,7 @@ impl<F: PrimeField + Absorb> LDT<F> for LinearCombinationLDT<F> {
                 .map(|_| FieldElementSize::Full)
                 .collect::<Vec<_>>(),
         );
-        transcript.submit_verifier_current_round(namespace, iop_trace!("ldt random coefficeints"));
+        transcript.submit_verifier_current_round(namespace, iop_trace!("ldt random coefficients"));
 
         let mut result_codewords = (0..param.domain.size())
             .map(|_| F::zero())


### PR DESCRIPTION
# Fix: Corrected typos in source files

## Changes
1. **Corrected typo in `ark-bcs/src/ldt/rl_ldt.rs:101`**:
   - "coefficeints" corrected to "coefficients".

2. **Corrected typo in `ark-bcs/src/bcs/transcript.rs:144`**:
   - "specfied" corrected to "specified".

## Purpose
- Enhanced code clarity and professionalism by fixing typos.
